### PR TITLE
LiteDB updated to 2.0.4 + added draggable splitter for collections/results

### DIFF
--- a/LiteDBViewer/LiteDBViewer.csproj
+++ b/LiteDBViewer/LiteDBViewer.csproj
@@ -42,8 +42,8 @@
       <HintPath>..\packages\JsonPrettyPrinter.1.0.1.1\lib\net35\JsonPrettyPrinterPlus.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LiteDB, Version=2.0.1.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
-      <HintPath>..\packages\LiteDB.2.0.1\lib\net35\LiteDB.dll</HintPath>
+    <Reference Include="LiteDB, Version=2.0.4.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
+      <HintPath>..\packages\LiteDB.2.0.4\lib\net35\LiteDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -127,7 +127,9 @@
     <EmbeddedResource Include="StringViewForm.resx">
       <DependentUpon>StringViewForm.cs</DependentUpon>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/LiteDBViewer/MainForm.Designer.cs
+++ b/LiteDBViewer/MainForm.Designer.cs
@@ -26,32 +26,35 @@
             this.txt_filename = new System.Windows.Forms.TextBox();
             this.btn_info = new System.Windows.Forms.Button();
             this.btn_export = new System.Windows.Forms.Button();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
             this.SuspendLayout();
             // 
             // lb_Collections
             // 
-            this.lb_Collections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left)));
+            this.lb_Collections.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lb_Collections.Font = new System.Drawing.Font("Courier New", 9F);
             this.lb_Collections.FormattingEnabled = true;
+            this.lb_Collections.IntegralHeight = false;
             this.lb_Collections.ItemHeight = 15;
-            this.lb_Collections.Location = new System.Drawing.Point(12, 117);
+            this.lb_Collections.Location = new System.Drawing.Point(0, 16);
             this.lb_Collections.Name = "lb_Collections";
-            this.lb_Collections.Size = new System.Drawing.Size(170, 259);
+            this.lb_Collections.Size = new System.Drawing.Size(180, 261);
             this.lb_Collections.TabIndex = 3;
             this.lb_Collections.SelectedIndexChanged += new System.EventHandler(this.listBox_SelectedIndexChanged);
             // 
             // dataGridView
             // 
-            this.dataGridView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.dataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView.Location = new System.Drawing.Point(188, 117);
+            this.dataGridView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataGridView.Location = new System.Drawing.Point(0, 16);
             this.dataGridView.Name = "dataGridView";
             this.dataGridView.ReadOnly = true;
-            this.dataGridView.Size = new System.Drawing.Size(481, 259);
+            this.dataGridView.Size = new System.Drawing.Size(476, 261);
             this.dataGridView.TabIndex = 5;
             this.dataGridView.MouseClick += new System.Windows.Forms.MouseEventHandler(this.dataGridView_MouseClick);
             this.dataGridView.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.dataGridView_MouseClick);
@@ -63,14 +66,14 @@
             this.txt_query.Font = new System.Drawing.Font("Courier New", 9F);
             this.txt_query.Location = new System.Drawing.Point(12, 71);
             this.txt_query.Name = "txt_query";
-            this.txt_query.Size = new System.Drawing.Size(657, 21);
+            this.txt_query.Size = new System.Drawing.Size(660, 21);
             this.txt_query.TabIndex = 1;
             this.txt_query.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox_KeyDown);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(9, 55);
+            this.label1.Location = new System.Drawing.Point(12, 55);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(38, 13);
             this.label1.TabIndex = 0;
@@ -79,25 +82,29 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(9, 101);
+            this.label2.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label2.Location = new System.Drawing.Point(0, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(61, 13);
+            this.label2.Padding = new System.Windows.Forms.Padding(0, 0, 0, 3);
+            this.label2.Size = new System.Drawing.Size(61, 16);
             this.label2.TabIndex = 2;
             this.label2.Text = "Collections:";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(185, 101);
+            this.label3.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label3.Location = new System.Drawing.Point(0, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(40, 13);
+            this.label3.Padding = new System.Windows.Forms.Padding(0, 0, 0, 3);
+            this.label3.Size = new System.Drawing.Size(40, 16);
             this.label3.TabIndex = 4;
             this.label3.Text = "Result:";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(9, 12);
+            this.label4.Location = new System.Drawing.Point(12, 12);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(52, 13);
             this.label4.TabIndex = 6;
@@ -139,21 +146,40 @@
             this.btn_export.UseVisualStyleBackColor = true;
             this.btn_export.Click += new System.EventHandler(this.Export_Click);
             // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer1.Location = new System.Drawing.Point(12, 98);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.lb_Collections);
+            this.splitContainer1.Panel1.Controls.Add(this.label2);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.dataGridView);
+            this.splitContainer1.Panel2.Controls.Add(this.label3);
+            this.splitContainer1.Size = new System.Drawing.Size(660, 277);
+            this.splitContainer1.SplitterDistance = 180;
+            this.splitContainer1.TabIndex = 10;
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(684, 387);
+            this.ClientSize = new System.Drawing.Size(684, 383);
+            this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.btn_export);
             this.Controls.Add(this.btn_info);
             this.Controls.Add(this.txt_filename);
             this.Controls.Add(this.label4);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.txt_query);
-            this.Controls.Add(this.dataGridView);
-            this.Controls.Add(this.lb_Collections);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MinimumSize = new System.Drawing.Size(700, 375);
             this.Name = "MainForm";
@@ -161,6 +187,12 @@
             this.Text = "LiteDB Viewer v{APPVERSION} - LiteDB v{DBVERSION}";
             this.Load += new System.EventHandler(this.MainForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).EndInit();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -178,6 +210,7 @@
         private System.Windows.Forms.TextBox txt_filename;
         private System.Windows.Forms.Button btn_info;
         private System.Windows.Forms.Button btn_export;
+        private System.Windows.Forms.SplitContainer splitContainer1;
     }
 }
 

--- a/LiteDBViewer/packages.config
+++ b/LiteDBViewer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="JsonPrettyPrinter" version="1.0.1.1" targetFramework="net40" />
-  <package id="LiteDB" version="2.0.1" targetFramework="net40" />
+  <package id="LiteDB" version="2.0.4" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
There was a blocking issue with previous version of LiteDB - it threw `NullReferenceException` if the database's `filename` contained whitespaces (for instance, "C:\ProgramData\New folder\Cache.db"). So I updated it to the latest one.

I also added a slitter between Collections and Result to the UI - this avoids a truncation of long collection names.